### PR TITLE
Simplify nameOverride construction and allow customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ proliferationStack:
 This chart is not currently available in a Helm chart museum or repository.  However, it
 can be installed as a Git submodule directly into a parent chart's `charts` directory.
 Alternatively, it could be simply cloned onto the same machine as a parent chart, then
-referenced as a local dependency.
+referenced as a local dependency.  Finally, this repository can be referenced as a Helm
+repository using [Helm-Git](https://github.com/aslafy-z/helm-git).
 
 ## Partial Templates
 

--- a/examples/various-webservers/templates/_helpers.tpl
+++ b/examples/various-webservers/templates/_helpers.tpl
@@ -42,6 +42,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Expand the verbose name of the chart and specific server.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "various-webservers.verbosename" -}}
+{{- .Values.baseNameOverride | default .Values.nameOverride | default .Chart.Name }}
+{{- range .Values.proliferationStack | default (list) -}}
+{{- printf "-%s-%s" .group .instance -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "various-webservers.chart" -}}
@@ -54,6 +65,7 @@ Common labels
 {{- define "various-webservers.labels" -}}
 helm.sh/chart: {{ include "various-webservers.chart" . }}
 {{ include "various-webservers.selectorLabels" . }}
+app.kubernetes.io/verbosename: {{ include "various-webservers.verbosename" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/examples/various-webservers/templates/_helpers.tpl
+++ b/examples/various-webservers/templates/_helpers.tpl
@@ -32,7 +32,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.baseNameOverride }}
+{{- $name := .Values.baseNameOverride | default .Values.nameOverride | default .Chart.Name }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/examples/various-webservers/templates/webservers.yaml
+++ b/examples/various-webservers/templates/webservers.yaml
@@ -1,1 +1,1 @@
-{{- list . "webserver-templates" "webserversOverrides" | include "proliferation.renderTemplatesFromDirectoryForAllKinds" -}}
+{{- list . "webserver-templates" "webservers" | include "proliferation.renderTemplatesFromDirectoryForAllKinds" -}}

--- a/examples/various-webservers/tests/webservers_test.yaml
+++ b/examples/various-webservers/tests/webservers_test.yaml
@@ -3,7 +3,7 @@ templates:
 - webservers.yaml
 tests:
 - it: refers to instances using webserversOverrides sub-key value
-  # webserversOverrides keys are firstof and secondof, which become e.g. firstofvarious-webservers
+  # webserversOverrides keys are first and second, which become e.g. various-webservers-first
   # through concatenation with the chart name.
   asserts:
   - hasDocuments:
@@ -14,11 +14,15 @@ tests:
     documentIndex: 0
   - matchRegex:
       path: metadata.name
-      pattern: -firstofvarious-webservers$
+      pattern: -various-webservers-first$
+    documentIndex: 0
+  - equal:
+      path: metadata.labels.app\.kubernetes\.io/verbosename
+      value: various-webservers-webservers-first
     documentIndex: 0
   - equal:
       path: spec.template.metadata.labels.app\.kubernetes\.io/name
-      value: firstofvarious-webservers
+      value: various-webservers-first
     documentIndex: 0
 
   - isKind:
@@ -26,11 +30,15 @@ tests:
     documentIndex: 1
   - matchRegex:
       path: metadata.name
-      pattern: -firstofvarious-webservers$
+      pattern: -various-webservers-first$
+    documentIndex: 1
+  - equal:
+      path: metadata.labels.app\.kubernetes\.io/verbosename
+      value: various-webservers-webservers-first
     documentIndex: 1
   - equal:
       path: spec.selector.app\.kubernetes\.io/name
-      value: firstofvarious-webservers
+      value: various-webservers-first
     documentIndex: 1
 
   - isKind:
@@ -38,11 +46,15 @@ tests:
     documentIndex: 2
   - matchRegex:
       path: metadata.name
-      pattern: -secondofvarious-webservers$
+      pattern: -various-webservers-second$
+    documentIndex: 2
+  - equal:
+      path: metadata.labels.app\.kubernetes\.io/verbosename
+      value: various-webservers-webservers-second
     documentIndex: 2
   - equal:
       path: spec.template.metadata.labels.app\.kubernetes\.io/name
-      value: secondofvarious-webservers
+      value: various-webservers-second
     documentIndex: 2
 
   - isKind:
@@ -50,20 +62,24 @@ tests:
     documentIndex: 3
   - matchRegex:
       path: metadata.name
-      pattern: -secondofvarious-webservers$
+      pattern: -various-webservers-second$
+    documentIndex: 3
+  - equal:
+      path: metadata.labels.app\.kubernetes\.io/verbosename
+      value: various-webservers-webservers-second
     documentIndex: 3
   - equal:
       path: spec.selector.app\.kubernetes\.io/name
-      value: secondofvarious-webservers
+      value: various-webservers-second
     documentIndex: 3
 
 - it: applies overriding values to the specified instances only
   set:
-    webserversOverrides:
-      firstof:
+    webservers:
+      first:
         autoscaling:
           enabled: true
-      secondof:
+      second:
         service:
           port: 8080
   asserts:
@@ -78,11 +94,11 @@ tests:
     documentIndex: 1
   - matchRegex:
       path: metadata.name
-      pattern: -firstofvarious-webservers$
+      pattern: -various-webservers-first$
     documentIndex: 1
   - matchRegex:
       path: spec.scaleTargetRef.name
-      pattern: -firstofvarious-webservers$
+      pattern: -various-webservers-first$
     documentIndex: 1
     # Instance secondof does not have autoscaling enabled, so gets no HPA.
 
@@ -92,7 +108,7 @@ tests:
     documentIndex: 2
   - matchRegex:
       path: metadata.name
-      pattern: -firstofvarious-webservers$
+      pattern: -various-webservers-first$
     documentIndex: 2
   - equal:
       path: spec.ports[0].port
@@ -107,7 +123,7 @@ tests:
     documentIndex: 4
   - matchRegex:
       path: metadata.name
-      pattern: -secondofvarious-webservers$
+      pattern: -various-webservers-second$
     documentIndex: 4
   - equal:
       path: spec.ports[0].port
@@ -118,8 +134,8 @@ tests:
   # This is useful to allow value overrides to eliminate instances that were specified at another
   # level of configuration.
   set:
-    webserversOverrides:
-      firstof: null
+    webservers:
+      first: null
   asserts:
   - hasDocuments:
       count: 2
@@ -129,11 +145,11 @@ tests:
     documentIndex: 0
   - matchRegex:
       path: metadata.name
-      pattern: -secondofvarious-webservers$
+      pattern: -various-webservers-second$
     documentIndex: 0
   - equal:
       path: spec.template.metadata.labels.app\.kubernetes\.io/name
-      value: secondofvarious-webservers
+      value: various-webservers-second
     documentIndex: 0
 
   - isKind:
@@ -141,9 +157,9 @@ tests:
     documentIndex: 1
   - matchRegex:
       path: metadata.name
-      pattern: -secondofvarious-webservers$
+      pattern: -various-webservers-second$
     documentIndex: 1
   - equal:
       path: spec.selector.app\.kubernetes\.io/name
-      value: secondofvarious-webservers
+      value: various-webservers-second
     documentIndex: 1

--- a/examples/various-webservers/values.yaml
+++ b/examples/various-webservers/values.yaml
@@ -81,6 +81,6 @@ tolerations: []
 
 affinity: {}
 
-webserversOverrides:
-  firstof: {}
-  secondof: {}
+webservers:
+  first: {}
+  second: {}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,18 +62,10 @@ Helpers for creating multiple similarly-configured instances from a single set o
         {{- $instanceValues := mustMergeOverwrite (mustDeepCopy $commonValues) $specificValues -}}
 
         {{- /* Set a name override for the chart in the course of processing the instance. */ -}}
-        {{- $_ := set $instanceValues "baseNameOverride" ($instanceValues.baseNameOverride | default $commonValues.nameOverride | default $context.Chart.Name) -}}
-        {{- if $commonValues.nameOverride -}}
-          {{- /* If there is a common nameOverride, append the kind's nameOverride, or its key. */ -}}
-          {{- with $specificValues.nameOverride | default $kind -}}
-            {{- $_ := printf "%s-%s" $commonValues.nameOverride . | set $instanceValues "nameOverride" -}}
-          {{- end -}}
-          {{- /* Otherwise, just use the common nameOverride (via the original merge). */ -}}
-        {{- else if not $specificValues.nameOverride | and $kind -}}
-          {{- /* If there is no common nameOverride but there is a kind-specific one, use that (via the original merge). */ -}}
-          {{- /* If there is no kind-specific nameOverride and the kind's key is empty, don't set a nameOverride. */ -}}
-          {{- /* If there is no kind-specific nameOverride, but the kind's key is non-empty, prepend it to the chart name. */ -}}
-          {{- $_ := printf "%s%s" $kind $context.Chart.Name | set $instanceValues "nameOverride" -}}
+        {{- $parentName := $commonValues.nameOverride | default $context.Chart.Name -}}
+        {{- $_ := $instanceValues.baseNameOverride | default $parentName | set $instanceValues "baseNameOverride" -}}
+        {{- if not $specificValues.nameOverride -}}
+          {{- $_ := printf "%s-%s" $parentName $kind | set $instanceValues "nameOverride" -}}
         {{- end -}}
 
         {{- /* Enumerate stack of proliferations performed to get this instance context. */ -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,6 +76,11 @@ Helpers for creating multiple similarly-configured instances from a single set o
           {{- $_ := printf "%s%s" $kind $context.Chart.Name | set $instanceValues "nameOverride" -}}
         {{- end -}}
 
+        {{- /* Enumerate stack of proliferations performed to get this instance context. */ -}}
+        {{- $proliferationEntry := dict "group" $kindsKey "instance" $kind -}}
+        {{- $proliferationStack := $commonValues.proliferationStack | default (list) -}}
+        {{- $_ := mustAppend $proliferationStack $proliferationEntry | set $instanceValues "proliferationStack" -}}
+
         {{- $allInstanceValues = mustAppend $allInstanceValues $instanceValues -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
Prior to this change, only the opinionated generated nameOverride could
be used to identify separate proliferated instances.  Furthermore,
nameOverride construction for proliferated contexts was opinionated
and over-complicated.

This change adds a new `.Values.proliferationStack` to each created
context, providing a list of specific contexts included in that created
context, in the order they were added.  It also moves to using a simpler
suffixing approach to `nameOverride` construction, expecting parent
charts to update their name-related partial templates if other patterns
are required.