### PR TITLE
Include explicit nameOverrides in proliferationStack

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,5 +8,5 @@ description: >
 
 type: library
 
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.0.0"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ wheels: 2
 wings: 0
 vehicles:
   plane:
+    nameOverride: mechanicalBird
     wings: 2
     models:
       biplane:
@@ -92,6 +93,7 @@ wings: 2
 proliferationStack:
 - group: vehicles
   instance: plane
+  nameOverride: mechanicalBird
 - group: models
   instance: fighter
 ```

--- a/examples/various-webservers/Chart.yaml
+++ b/examples/various-webservers/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 dependencies:
 - name: resource-proliferation
-  version: ^0.2.0
+  version: ^0.2.1
   repository: file://../..
 
 version: 0.1.0

--- a/examples/various-webservers/templates/_helpers.tpl
+++ b/examples/various-webservers/templates/_helpers.tpl
@@ -46,10 +46,17 @@ Expand the verbose name of the chart and specific server.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "various-webservers.verbosename" -}}
-{{- .Values.baseNameOverride | default .Values.nameOverride | default .Chart.Name }}
+{{- $baseName := .Values.baseNameOverride | default .Values.nameOverride | default .Chart.Name }}
+{{- $nameExtension := "" -}}
 {{- range .Values.proliferationStack | default (list) -}}
-{{- printf "-%s-%s" .group .instance -}}
+{{- if .nameOverride -}}
+{{- $nameExtension = "" -}}
+{{- $baseName = .nameOverride -}}
+{{- else -}}
+{{- $nameExtension = printf "%s-%s-%s" $nameExtension .group .instance -}}
 {{- end -}}
+{{- end -}}
+{{- printf "%s%s" $baseName $nameExtension -}}
 {{- end }}
 
 {{/*

--- a/examples/various-webservers/tests/webservers_test.yaml
+++ b/examples/various-webservers/tests/webservers_test.yaml
@@ -163,3 +163,26 @@ tests:
       path: spec.selector.app\.kubernetes\.io/name
       value: various-webservers-second
     documentIndex: 1
+
+- it: makes explicit nameOverrides available in the proliferationStack
+  # This is useful when constructing non-default naming conventions (as demonstrated
+  # in this chart in the verbosename template) that still need to respect name overrides.
+  set:
+    webservers:
+      first:
+        nameOverride: test
+  asserts:
+  - hasDocuments:
+      count: 4
+
+  - isKind:
+      of: Deployment
+    documentIndex: 0
+  - matchRegex:
+      path: metadata.name
+      pattern: -test$
+    documentIndex: 0
+  - equal:
+      path: metadata.labels.app\.kubernetes\.io/verbosename
+      value: test
+    documentIndex: 0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -61,17 +61,19 @@ Helpers for creating multiple similarly-configured instances from a single set o
         */ -}}
         {{- $instanceValues := mustMergeOverwrite (mustDeepCopy $commonValues) $specificValues -}}
 
-        {{- /* Set a name override for the chart in the course of processing the instance. */ -}}
-        {{- $parentName := $commonValues.nameOverride | default $context.Chart.Name -}}
-        {{- $_ := $instanceValues.baseNameOverride | default $parentName | set $instanceValues "baseNameOverride" -}}
-        {{- if not $specificValues.nameOverride -}}
-          {{- $_ := printf "%s-%s" $parentName $kind | set $instanceValues "nameOverride" -}}
-        {{- end -}}
-
         {{- /* Enumerate stack of proliferations performed to get this instance context. */ -}}
         {{- $proliferationEntry := dict "group" $kindsKey "instance" $kind -}}
         {{- $proliferationStack := $commonValues.proliferationStack | default (list) -}}
         {{- $_ := mustAppend $proliferationStack $proliferationEntry | set $instanceValues "proliferationStack" -}}
+
+        {{- /* Set a name override for the chart in the course of processing the instance. */ -}}
+        {{- $parentName := $commonValues.nameOverride | default $context.Chart.Name -}}
+        {{- $_ := $instanceValues.baseNameOverride | default $parentName | set $instanceValues "baseNameOverride" -}}
+        {{- if $specificValues.nameOverride -}}
+          {{- $_ := set $proliferationEntry "nameOverride" $specificValues.nameOverride -}}
+        {{- else -}}
+          {{- $_ := printf "%s-%s" $parentName $kind | set $instanceValues "nameOverride" -}}
+        {{- end -}}
 
         {{- $allInstanceValues = mustAppend $allInstanceValues $instanceValues -}}
       {{- end -}}


### PR DESCRIPTION
Prior to this change, more complex name construction was possible, but
in so doing would lose information about explicit nameOverrides at
different levels of a proliferation stack.

This change includes any nameOverride explicitly specified at a given
level in the proliferationStack, thereby facilitating their use in the
recreation of the default behaviour, which is a minumum functionality
for name construction.